### PR TITLE
Fix to display the groupfolders' files 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8",
+    "version": "0.9",
     "require": {
         "vlucas/phpdotenv": "^5.3",
         "aws/aws-sdk-php": "^3.188",

--- a/main.php
+++ b/main.php
@@ -213,7 +213,7 @@ if (in_array(strtolower($_ENV['S3_PROVIDER_NAME']), $PROVIDERS_S3_SWIFT)) {
     $newIdLocalStorage = 'object::store:' . strtolower($_ENV['S3_BUCKET_NAME']);
 } else {
     $migrateLogger->info('Updating the target datadirectory for S3 Compatible');
-    $newIdLocalStorage = 'object::store:' . strtolower($_ENV['S3_PROVIDER_NAME']) . '::' . $_ENV['S3_BUCKET_NAME'];
+    $newIdLocalStorage = 'object::store:amazon::' . $_ENV['S3_BUCKET_NAME'];
 }
 $migrateLogger->info('Updating the Storage database table for LocalUser');
 $db->updateIdStorage($localStorage->numeric_id, $newIdLocalStorage);
@@ -221,7 +221,6 @@ $db->updateIdStorage($localStorage->numeric_id, $newIdLocalStorage);
 // Creating the new config for Nextcloud
 $migrateLogger->info('Preparing the new config file for Nextcloud');
 $NEW_CONFIG_NEXTCLOUD = $CONFIG_NEXTCLOUD; // Don't clone. $NEW_CONFIG_NEXTCLOUD has a new address memory.
-$NEW_CONFIG_NEXTCLOUD['maintenance'] = false;
 if (in_array(strtolower($_ENV['S3_PROVIDER_NAME']), $PROVIDERS_S3_SWIFT)) {
     $NEW_CONFIG_NEXTCLOUD['objectstore'] = [
         'class' => 'OC\\Files\\ObjectStore\\Swift',


### PR DESCRIPTION
When the migration is complted, I check the oc_storages database table if all entries are corrects.
However, there is always a new entry like "object::store:amazon::<bucket-name>" for the "local::<datadirectory>" storage.
But, I always renamed the "local::<datadirectory>" like this : "object::store:<provider>::<bucket-name>".

I compared the groupfolders' files and the oc_storage database table.

```
MariaDB [my-nextcloud]> select * from oc_storages;
+------------+---------------------------------------+-----------+--------------+
| numeric_id | id                                    | available | last_checked |
+------------+---------------------------------------+-----------+--------------+
|          1 | object::user:admin                    |         1 |         NULL |
|          2 | object::store:scaleway::arawa-test-nc |         1 |         NULL |
|          3 | object::user:user1                   |         1 |         NULL |
|          4 | object::user:user2                  |         1 |         NULL |
|          5 | object::user:user3                  |         1 |         NULL |
|          6 | object::user:user4                  |         1 |         NULL |
|          7 | object::user:user5                 |         1 |         NULL |
|          8 | object::user:user6                  |         1 |         NULL |
|          9 | object::user:user7                  |         1 |         NULL |
|         10 | object::user:user8                |         1 |         NULL |
|         11 | object::user:user9               |         1 |         NULL |
|         12 | object::user:user10                   |         1 |         NULL |
|         13 | object::user:user11                 |         1 |         NULL |
|        207 | object::user:user12                  |         1 |         NULL |
|        208 | object::user:user13                |         1 |         NULL |
|        209 | object::user:user14                   |         1 |         NULL |
|        237 | object::store:amazon::arawa-test-nc   |         1 |         NULL |
+------------+---------------------------------------+-----------+--------------+
17 rows in set (0.000 sec)

MariaDB [my-nextcloud]> select * from oc_filecache where path like "%__groupfolders%" and not mimetype="2";
+--------+---------+----------------------------------------------------------------------+----------------------------------+--------+-----------------------------------------------------+----------+----------+---------+------------+---------------+-----------+------------------+----------------------------------+-------------+----------+
| fileid | storage | path                                                                 | path_hash                        | parent | name                                                | mimetype | mimepart | size    | mtime      | storage_mtime | encrypted | unencrypted_size | etag                             | permissions | checksum |
+--------+---------+----------------------------------------------------------------------+----------------------------------+--------+-----------------------------------------------------+----------+----------+---------+------------+---------------+-----------+------------------+----------------------------------+-------------+----------+
|  66869 |       2 | appdata_oc9c1ry07kej/theming/1/icon-groupfolders-folder-group.svg    | 5fbc1669743ed092debaa04fec77172d |     53 | icon-groupfolders-folder-group.svg                  |       21 |        8 |    1493 | 1653909903 |    1653909903 |         0 |                0 | f52bd8bad3b8aa70bc0fb75df2633d7c |          27 |          |
|  66870 |       2 | __groupfolders/1/2020-10-06-mobilizon-illustration-D_realisation.jpg | 023609576a64d1666d2564b6bf04c2f2 |  66868 | 2020-10-06-mobilizon-illustration-D_realisation.jpg |       16 |        8 | 1544326 | 1603802750 |    1603802750 |         0 |                0 | fed9fedb085d370d06c5e42210a25f96 |          27 |          |
|  67016 |       2 | __groupfolders/1/octocat-ironman.png                                 | 341385462957a089652aa03e56cdbf73 |  66868 | octocat-ironman.png                                 |        9 |        8 |   32875 | 1651578938 |    1651578938 |         0 |                0 | d04bb712cff9904ce51c995b93d7a9d6 |          27 |          |
|  68490 |     237 | appdata_oc9c1ry07kej/theming/1/icon-groupfolders-folder-group.svg    | 5fbc1669743ed092debaa04fec77172d |  68489 | icon-groupfolders-folder-group.svg                  |       21 |        8 |    1493 | 1653927688 |    1653927688 |         0 |                0 | 6294ef08836cd                    |          27 | NULL     |
|  68580 |     237 | __groupfolders/1/my-example-s3.md                                    | 61bb5639d0eb57d2b98adc4c3cc3aaef |  68435 | my-example-s3.md                                    |        6 |        5 |       0 | 1653982736 |    1653982736 |         0 |                0 | 6295c61285371                    |          27 | NULL     |
+--------+---------+----------------------------------------------------------------------+----------------------------------+--------+-----------------------------------------------------+----------+----------+---------+------------+---------------+-----------+------------------+----------------------------------+-------------+----------+

```

So, I immediately thought that the problem is due to a conflict on which files to choose between the 237 and 2 storage.

So, I renamed the local storage as "object::store:amazon::<bucket-name>" and it's resolve my fix.