### PR TITLE
Replace dies by the new SqlException exception

### DIFF
--- a/lib/Db/Mapper/FilesMapper.php
+++ b/lib/Db/Mapper/FilesMapper.php
@@ -10,6 +10,7 @@ use MigrationS3NC\Entity\FileUsers;
 use MigrationS3NC\Db\DatabaseSingleton;
 use MigrationS3NC\Logger\LoggerSingleton;
 use MigrationS3NC\Entity\FileLocalStorage;
+use MigrationS3NC\Exceptions\SqlException;
 
 class FilesMapper
 {
@@ -65,7 +66,7 @@ class FilesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
+            throw new SqlException($e->getMessage());
 
         }
     }
@@ -115,8 +116,7 @@ class FilesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
-
+            throw new SqlException($e->getMessage());
         }
     }
 }

--- a/lib/Db/Mapper/MimeTypesMapper.php
+++ b/lib/Db/Mapper/MimeTypesMapper.php
@@ -3,6 +3,7 @@
 namespace MigrationS3NC\Db\Mapper;
 
 use MigrationS3NC\Db\DatabaseSingleton;
+use MigrationS3NC\Exceptions\SqlException;
 use MigrationS3NC\Logger\LoggerSingleton;
 use PDOException;
 
@@ -39,7 +40,7 @@ class MimeTypesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
+            throw new SqlException($e->getMessage());
 
         }
     }

--- a/lib/Db/Mapper/StoragesMapper.php
+++ b/lib/Db/Mapper/StoragesMapper.php
@@ -7,6 +7,7 @@ require_once 'lib/Entities/Storage.php';
 use PDOException;
 use MigrationS3NC\Entity\Storage;
 use MigrationS3NC\Db\DatabaseSingleton;
+use MigrationS3NC\Exceptions\SqlException;
 use MigrationS3NC\Logger\LoggerSingleton;
 
 class StoragesMapper
@@ -41,7 +42,7 @@ class StoragesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
+            throw new SqlException($e->getMessage());
         }
     }
 
@@ -67,7 +68,7 @@ class StoragesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
+            throw new SqlException($e->getMessage());
         }
     }
 
@@ -94,7 +95,7 @@ class StoragesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
+            throw new SqlException($e->getMessage());
             
         }
     }
@@ -123,7 +124,7 @@ class StoragesMapper
             ->getLogger()
             ->error($e->getMessage());
 
-            die($e->getMessage());
+            throw new SqlException($e->getMessage());
 
         }
     }

--- a/lib/Exceptions/SqlException.php
+++ b/lib/Exceptions/SqlException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MigrationS3NC\Exceptions;
+
+use Exception;
+
+class SqlException extends Exception
+{
+    public function __construct($message)
+    {
+        parent::__construct($message);
+    }
+}


### PR DESCRIPTION
It's a good practice to return an Exception and not a die when we have an error.